### PR TITLE
Ignore the directory wheelhouse/ which is created while compiling Ceph.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 *.pyc
 rook_client/tests/test_README.py
 .tox
+wheelhouse/


### PR DESCRIPTION
Signed-off-by: Volker Theile <vtheile@suse.com>