### PR TITLE
Pin mkcodes to a version that does not require python > 3.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ pytest
 requests
 pyyaml
 markdown
--e git+https://github.com/ryneeverett/mkcodes.git#egg=mkcodes
+-e git+https://github.com/ryneeverett/mkcodes.git@8b073b6ca0773008ca2a06ffd1c22b2c1fc1cce4#egg=mkcodes
 docopt
 tox


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/52659

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>